### PR TITLE
Ffmpeg for bitrate option on packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ It will then check the manifest and package resources into an `.lpf` archive –
 
 This means you can also use this command as a quick and simple packager for W3C audiobooks if you already have everything required.
 
+If you want to modify the bitrate of packaged audio, you can run:
+
+```
+audiopkger package -b 128
+```
+
+Make sure you have [FFMPEG installed](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/wiki) before running this command or else it will obviously fail.
+
+This process may take a while depending on the size of your audiobook, but it won’t overwrite your audio files.
+
+Note Audiopkger doesn’t attempt to check the bitrate of the source audio files, it will blindly follow your instructions.
+
 Quick tip: rename the `.lpf` extension to `.zip` to easily unzip this package if needed.
 
 ### Misc
@@ -161,6 +173,7 @@ audiopkger [command]
   help ............... show help menu
   init ............... create an audiobook manifest (and toc) in the directory
   package ............ package the directory as .lpf
+    --bitrate, -b ......... use FFMPEG to modify the bitrate of packaged audio
   toc ................ create a Table of Contents from the manifest
   version ............ show the version
 ```

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ This means you can also use this command as a quick and simple packager for W3C 
 If you want to modify the bitrate of packaged audio, you can run:
 
 ```
-audiopkger package -b 128
+audiopkger package -b <number>
 ```
 
 Make sure you have [FFMPEG installed](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/wiki) before running this command or else it will obviously fail.
@@ -149,7 +149,7 @@ This process may take a while depending on the size of your audiobook, but it wo
 
 Note Audiopkger doesn’t attempt to check the bitrate of the source audio files, it will blindly follow your instructions.
 
-Quick tip: rename the `.lpf` extension to `.zip` to easily unzip this package if needed.
+Quick tip: rename the `.lpf` extension to `.zip` to easily unzip this package if needed. If you’re using Visual Studio Code, you could also install [this extension](https://github.com/JayPanoz/vscode-zipexplorer).
 
 ### Misc
 

--- a/cmds/help.js
+++ b/cmds/help.js
@@ -6,6 +6,7 @@ const menu = `
     help ............... show help menu
     init ............... create an audiobook manifest (and toc) in the directory
     package ............ package the directory as .lpf
+      --bitrate, -b ......... use FFMPEG to modify the bitrate of packaged audio
     toc ................ create a Table of Contents from the manifest
     version ............ show the version\n`;
 

--- a/cmds/package.js
+++ b/cmds/package.js
@@ -3,6 +3,7 @@ const path = require("path");
 const fileReader = require("../utils/fs/fileReader");
 const error = require("../utils/console/error");
 const log = require("../utils/console/log");
+const ffmpegProcess = require("../utils/fs/ffmpeg");
 const archiver = require("archiver");
 const prettyBytes = require("pretty-bytes");
 const messager = require("../data/messages");
@@ -10,8 +11,10 @@ const messager = require("../data/messages");
 const basePath = process.cwd();
 const filename = path.basename(basePath);
 
-module.exports = () => {
+module.exports = (args) => {
   try {
+    const bitrate = args.bitrate || args.b;
+
     log(messager().info.launched("package"));
 
     const manifestFile = fileReader("publication.json");
@@ -22,7 +25,7 @@ module.exports = () => {
     const output = fs.createWriteStream(`./${filename}.lpf`);
     const archive = archiver("zip");
 
-    output.on("close", () => {
+    output.on("finish", () => {
       const fileSize = prettyBytes(archive.pointer());
       log(messager().info.created(`${filename}.lpf archive (${fileSize})`));
     });
@@ -50,7 +53,12 @@ module.exports = () => {
 
     for (const audio of audioItems) {
       const audioFile = audio.url;
-      archive.file(audioFile, {store: true});
+      if (bitrate) {
+        const tmpStream = ffmpegProcess(audioFile, bitrate);
+        archive.append(tmpStream, {name: audioFile, store: true});
+      } else {
+        archive.file(audioFile, {store: true});
+      }
     }
 
     archive.finalize();

--- a/data/messages.js
+++ b/data/messages.js
@@ -42,10 +42,24 @@ module.exports = () => {
         return `\nThe ${filestring} will be created in the current directory...\n`;
       },
       created: (filestring) => {
-        return chalk.green(`The ${filestring} has been created.\n`);
+        return chalk.bold.green(`The ${filestring} has been created.\n`);
       },
       updating: (filestring) => {
         return chalk.yellow(`Updating the ${filestring}...\n`);
+      }
+    },
+    ffmpeg: {
+      start: (filestring) => {
+        return `"${filestring}" is being processed by FFMPEG…\n`
+      },
+      progress: (progress, filestring) => {
+        return `Processing "${filestring}": ${progress.percent}% done\n`
+      },
+      error: (err) => {
+        return chalk.bold.red(`× Could not process audio: ${err.message}\n`);
+      },
+      end: (filestring) => {
+        return chalk.green(`✓ "${filestring}" was successfuly processed.\n`);
       }
     },
     error: {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = () => {
       require("./cmds/init")();
       break;
     case "package":
-      require("./cmds/package")();
+      require("./cmds/package")(args);
       break;
     case "toc":
       require("./cmds/toc")();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audiopkger",
-  "version": "0.15.1",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -304,6 +304,15 @@
         "strtok3": "^5.0.1",
         "token-types": "^2.0.0",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "fluent-ffmpeg": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz",
+      "integrity": "sha1-yVLeIkD4EuvaCqgAbXd27irPfXQ=",
+      "requires": {
+        "async": ">=0.2.9",
+        "which": "^1.1.1"
       }
     },
     "fs-constants": {
@@ -687,6 +696,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -1038,6 +1052,14 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audiopkger",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "A command-line tool to generate and package W3C audiobooks",
   "main": "index.js",
   "bin": {
@@ -32,6 +32,7 @@
     "archiver": "^3.1.1",
     "bcp47-validate": "^1.0.0",
     "chalk": "^3.0.0",
+    "fluent-ffmpeg": "^2.1.2",
     "glob": "^7.1.6",
     "inquirer": "^7.0.3",
     "inquirer-datepicker-prompt": "^0.4.2",

--- a/utils/fs/ffmpeg.js
+++ b/utils/fs/ffmpeg.js
@@ -1,0 +1,26 @@
+const path = require("path");
+const error = require("../console/error");
+const log = require("../console/log");
+const ffmpeg = require("fluent-ffmpeg");
+const messager = require("../../data/messages");
+
+module.exports = (audioFile, bitrate) => {
+  const fileExt = path.extname(audioFile).substring(1).toLowerCase();
+  
+  return ffmpeg(audioFile)
+    .format(fileExt)
+    .audioBitrate(bitrate)
+    .on("start", () => {
+      log(messager().ffmpeg.start(audioFile));
+    })
+  /*  .on("progress", (progress) => {
+      log(messager().ffmpeg.progress(progress));
+    }) */
+    .on("error", (err) => {
+      error(messager().ffmpeg.error(err));
+    })
+    .on("end", () => {
+      log(messager().ffmpeg.end(audioFile));
+    })
+    .pipe();
+}


### PR DESCRIPTION
This adds fluent-ffmpeg as a dependency to enable a bitrate option when packaging the audiobook. 

It’s using a passthrough stream so that the src audio files are not overwritten. 

You obviously need FFMPEG installed for it to work. 